### PR TITLE
No longer import data acquired from quality report

### DIFF
--- a/Code/importerjson/src/importer/ImpCommit.java
+++ b/Code/importerjson/src/importer/ImpCommit.java
@@ -295,7 +295,7 @@ public class ImpCommit extends BaseImport {
     }
 
     /**
-     * Updates the JiraID's of the VCS developer table. It uses a json file to read
+     * Updates the JiraID's of the VCS/LDAP developer tables. It uses a json file to read
      * all the aliases found on the version control system and then links them to the JiraID's.
      * Best is to do this after collecting all the records of all the projects.
      */

--- a/Code/importerjson/src/importer/ImpMetricValue.java
+++ b/Code/importerjson/src/importer/ImpMetricValue.java
@@ -74,80 +74,11 @@ public class ImpMetricValue extends BaseImport {
             this.projectID = projectID;
         }
         
-        private void readPath(String path) throws IOException, MetricReadException, SQLException, PropertyVetoException {
-            // Parse the path, consisting of the actual location followed by
-            // a fragment identifier (#), after which we have a list of flags,
-            // delimited by vertical bars (|). The first flag is always the
-            // tracker record from which to start reading the history file.
-            // Other flags are "compact" to use a compact history reader, and
-            // "local" to indicate that the path is a local file.
-            String[] parts = path.split("#");
-            String location = parts[0];
-            List<String> flags = Arrays.asList(parts[1].split("\\|"));
-            
-            MetricReader reader;
-            if (flags.contains("compact")) {
-                reader = new CompactHistoryReader(this);
-            }
-            else {
-                reader = new HistoryReader(this);
-            }
-            
-            reader.parseFragment(flags.get(0));
-            
-            // For compatibility, locations ending in a vertical bar are local.
-            boolean local;
-            if (location.endsWith("|")) {
-                location = location.substring(0, location.length() - 1);
-                local = true;
-            }
-            else {
-                local = flags.contains("local");
-            }
-            boolean compression = flags.contains("compression=gz");
-            if (!compression && !flags.contains("compression=")) {
-                compression = location.endsWith(".gz");
-            }
-            
-            if (local) {
-                readLocal(reader, location, compression);
-            }
-            else {
-                readNetworked(reader, new URL(location), compression);
-            }
-        }
-        
-        public void readLocal(MetricReader reader, String path, boolean compression) throws IOException, MetricReadException, SQLException, PropertyVetoException {
-            try (
-                InputStream is = new FileInputStream(path);
-                InputStream gis = compression ? new GZIPInputStream(is, BUFFER_SIZE) : is
-            ) {
-                reader.read(gis);
-            }
-        }
-
-        public void readNetworked(MetricReader reader, URL url, boolean compression) throws IOException, MetricReadException, SQLException, PropertyVetoException {
-            URLConnection con = url.openConnection();
-            con.connect();
-            try (
-                InputStream is = con.getInputStream();
-                InputStream gis = compression ? new GZIPInputStream(is, BUFFER_SIZE) : is
-            ) {
-                reader.read(gis);
-            }
-        }
-        
         public void readBufferedJSON(BufferedJSONReader br) throws IOException, MetricReadException, SQLException, PropertyVetoException {
             Object object;
             try {
                 while ((object = br.readObject()) != null) {
-                    if (object instanceof String) {
-                        readPath((String) object);
-                        break;
-                    }
-                    else {
-                        handleObject((JSONObject) object);
-                    }
+                    handleObject((JSONObject) object);
                 }
             }
             catch (ParseException ex) {
@@ -163,13 +94,17 @@ public class ImpMetricValue extends BaseImport {
             String value = (String) jsonObject.get("value");
             String category = (String) jsonObject.get("category");
             String date = (String) jsonObject.get("date");
-            String since_date = (String) jsonObject.get("since_date");
+            String start = (String) jsonObject.get("since_date");
             MetricName nameParts = null;
             if (base_name != null && domain_name != null) {
                 nameParts = new MetricName(metric_name, base_name, domain_name, domain_type);
             }
 
-            insert(metric_name, Integer.parseInt(value), category, Timestamp.valueOf(date), Timestamp.valueOf(since_date), nameParts);
+            Timestamp since_date = null;
+            if (start != null) {
+                since_date = Timestamp.valueOf(start);
+            }
+            insert(metric_name, Integer.parseInt(value), category, Timestamp.valueOf(date), since_date, nameParts);
         }
 
         public void insert(String metric_name, float value, String category, Timestamp date, Timestamp since_date, MetricName nameParts) throws SQLException, PropertyVetoException {
@@ -227,262 +162,6 @@ public class ImpMetricValue extends BaseImport {
             super(message, cause);
         }
     }
-    
-    private abstract static class MetricReader {
-        protected final MetricCollector collector;
-        protected final static Logger LOGGER = Logger.getLogger("importer");
-        
-        public MetricReader(MetricCollector collector) {
-            this.collector = collector;
-        }
-        
-        public abstract void parseFragment(String fragment);
-        public abstract void read(InputStream is) throws IOException, MetricReadException, SQLException, PropertyVetoException;
-    }
-    
-    private final static class HistoryReader extends MetricReader {
-        public static final int BUFFER_SIZE = 65536;
-        private int start_from = 0;
-        private final StringReplacer replacer;
-        private final JSONParser parser = new JSONParser();
-
-        public HistoryReader(MetricCollector collector) {
-            super(collector);
-            replacer = new StringReplacer();
-            replacer.add("(\"", "[\"").add("\")", "\"]").add(", }", "}");
-        }
-
-        @Override
-        public void parseFragment(String fragment) {
-            try {
-                start_from = Integer.parseInt(fragment);
-            }
-            catch (NumberFormatException ex) {
-                LOGGER.logp(Level.FINE, "HistoryReader", "parseFragment", "Fragment cannot be parsed", ex);
-            }
-        }
-        
-        @Override
-        public void read(InputStream is) throws IOException, MetricReadException, SQLException, PropertyVetoException {
-            int line_count = 0;
-            Boolean success = false;
-            try (
-                Reader reader = new InputStreamReader(is, "UTF-8");
-                BufferedReader br = new BufferedReader(reader, BUFFER_SIZE)
-            ) {
-                String line;
-                JSONObject metric_row;
-                while ((line = br.readLine()) != null) {
-                    line_count++;
-                    if (line_count <= start_from || line.isEmpty()) {
-                        continue;
-                    }
-                    
-                    metric_row = parseRow(line);
-                    
-                    Timestamp date = parseDate(metric_row);
-                    if (date != null) {
-                        for (Iterator it = metric_row.entrySet().iterator(); it.hasNext();) {
-                            Map.Entry pair = (Map.Entry)it.next();
-                            Object data = pair.getValue();
-                            if (data instanceof JSONArray) {
-                                JSONArray metric_data = (JSONArray) data;
-                                String metric_name = (String) pair.getKey();
-
-                                String value = (String) metric_data.get(0);
-                                String category = (String) metric_data.get(1);
-
-                                Timestamp since_date;
-                                if (metric_data.size() > 2) {
-                                    String since_time = (String) metric_data.get(2);
-                                    since_date = Timestamp.valueOf(since_time);
-                                }
-                                else {
-                                    since_date = null;
-                                }
-
-                                collector.insert(metric_name, Integer.parseInt(value), category, date, since_date);
-                            }
-                        }
-                    }
-                }
-                success = true;
-            }
-            catch (MetricReadException e) {
-                throw new MetricReadException("Problem at line " + line_count, e);
-            }
-            finally {
-                // Write a progress file so that we can read from the correct location.
-                // Do this upon midway failure as well, but not if we did not read further than the start line.
-                // If we failed somewhere midway, then next time start from the line we failed on.
-                if (line_count > start_from) {
-                    try (PrintWriter writer = new PrintWriter(new File(collector.getPath(), "history_line_count.txt"))) {
-                        writer.println(String.valueOf(success ? line_count : line_count-1));
-                    }
-                }
-            }
-        }
-        
-        private JSONObject parseRow(String line) throws MetricReadException {
-            String row = replacer.execute(line);
-            try {
-                return (JSONObject) parser.parse(row);
-            }
-            catch (ParseException e) {
-                throw new MetricReadException("Could not parse row:\n" + row, e);
-            }
-        }
-        
-        private Timestamp parseDate(JSONObject metric_row) {
-            try {
-                return Timestamp.valueOf((String) metric_row.get("date"));
-            }
-            catch (IllegalArgumentException ex) {
-                LOGGER.logp(Level.SEVERE, "HistoryReader", "parseDate", "Date parsing exception", ex);
-                return null;
-            }
-        }
-    }
-    
-    private final static class CompactHistoryReader extends MetricReader {
-        private String max_record_time = "";
-        private String current_record_time = "";
-
-        public CompactHistoryReader(MetricCollector collector) {
-            super(collector);
-        }
-        
-        @Override
-        public void parseFragment(String fragment) {
-            if ("0".equals(fragment)) {
-                try {
-                    Timestamp latest_date = collector.mDB.get_latest_metric_date(collector.projectID);
-                    if (latest_date != null) {
-                        max_record_time = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(latest_date);
-                    }
-                } catch (SQLException | PropertyVetoException ex) {
-                    LOGGER.log(Level.SEVERE, null, ex);
-                }
-            }
-            else {
-                try {
-                    Timestamp.valueOf(fragment);
-                    max_record_time = fragment;
-                }
-                catch (IllegalArgumentException ex) {
-                    LOGGER.logp(Level.FINE, "CompactHistoryReader", "parseFragment", "Could not parse record time from fragment");
-                }
-            }
-            current_record_time = max_record_time;
-        }
-        
-        @Override
-        public void read(InputStream is) throws IOException, MetricReadException, SQLException, PropertyVetoException {
-            JSONParser parser = new JSONParser();
-            try (Reader reader = new InputStreamReader(is, "UTF-8")) {
-                JSONObject object = (JSONObject) parser.parse(reader);
-                
-                JSONArray dateArray = (JSONArray) object.get("dates");
-                int max_index = dateArray.size();
-                String[] dates = parseDates(dateArray, max_index);
-                JSONObject metrics = (JSONObject) object.get("metrics");
-                
-                for (Iterator it = metrics.entrySet().iterator(); it.hasNext();) {
-                    Map.Entry pair = (Map.Entry)it.next();
-                    String metric_name = (String) pair.getKey();
-                    JSONArray data = (JSONArray) pair.getValue();
-                    
-                    if (!parseMetric(metric_name, data, dates, max_index)) {
-                        break;
-                    }
-                }
-                
-                // Write a progress file so that we can read new metric value
-                // additions later on. Only do this if the import succeeds.
-                if (!max_record_time.isEmpty()) {
-                    try (PrintWriter writer = new PrintWriter(new File(collector.getPath(), "history_record_time.txt"))) {
-                        writer.println(String.valueOf(max_record_time));
-                    }
-                }
-            }
-            catch (ParseException ex) {
-                throw new MetricReadException("Cannot parse JSON object", ex);
-            }
-        }
-        
-        private String[] parseDates(JSONArray dateArray, int length) {
-            List<String> dateList = new ArrayList<>();
-            for (Object item : dateArray) {
-                dateList.add((String)item);
-            }
-            return dateList.toArray(new String[length]);
-        }
-
-        private boolean parseMetric(String metric_name, JSONArray data, String[] dates, int max_index) throws MetricReadException, SQLException, PropertyVetoException {
-            int previous_index = 0;
-            for (Object record : data) {
-                JSONObject measurement = (JSONObject) record;
-                String start_time = (String) measurement.get("start");
-                String end_time = (String) measurement.get("end");
-                String status = (String) measurement.get("status");
-                Object value = measurement.get("value");
-                float metric_value;
-                if (value == null) {
-                    metric_value = -1;
-                }
-                else if (value instanceof Long) {
-                    metric_value = ((Long) value).floatValue();
-                }
-                else if (value instanceof Double) {
-                    metric_value = ((Double) value).floatValue();
-                }
-                else {
-                    throw new MetricReadException("Unexpected type of value: " + value.getClass().getSimpleName());
-                }
-
-                Timestamp since_date = Timestamp.valueOf(start_time);
-
-                // Search for the indexes of the dates that correspond with the
-                // start and end dates, such that we can loop over this range to
-                // add all measurement dates. For the start time, use right
-                // bisection if the start time is set from the max record time.
-                // In all other cases, use left bisection.
-
-                int start_index;
-                if (start_time.compareTo(current_record_time) < 0) {
-                    start_time = current_record_time;
-                    start_index = Bisect.bisectRight(dates, start_time, previous_index, max_index);
-                }
-                else {
-                    start_index = Bisect.bisectLeft(dates, start_time, previous_index, max_index);
-                }
-                if (start_index >= max_index) {
-                    LOGGER.log(Level.INFO, "Start time {0} with index {1} out of range ({2}, {3})", new Object[]{start_time, start_index, previous_index, max_index});
-                    return false;
-                }
-                
-                int end_index = Bisect.bisectLeft(dates, end_time, start_index, max_index);
-                
-                for (int i = start_index; i < end_index; i++) {
-                    String date = dates[i];
-                    collector.insert(metric_name, metric_value, status, Timestamp.valueOf(date), since_date);
-                }
-
-                // Track latest date indices and new dates.
-                previous_index = end_index;
-                if (end_time.compareTo(max_record_time) > 0) {
-                    max_record_time = end_time;
-                }
-                
-                if (end_index >= max_index) {
-                    LOGGER.log(Level.WARNING, "End time {0} with index {1} went out of range, max index is {2}", new Object[]{end_time, end_index, max_index});
-                    return true;
-                }
-            }
-            
-            return true;
-        }
-    }
 
     @Override
     public void parser() {
@@ -491,15 +170,9 @@ public class ImpMetricValue extends BaseImport {
         for (String file : getImportFiles()) {
             File path = new File(exportPath, file);
             try (MetricCollector collector = new MetricCollector(exportPath, getProjectID())) {
-                if (i == 0) {
-                    // Read metrics JSON using buffered readers so that Java does not run out of memory
-                    try (BufferedJSONReader br = new BufferedJSONReader(new FileReader(path))) {
-                        collector.readBufferedJSON(br);
-                    }
-                }
-                else {
-                    // Read additional JSON files as compact history files.
-                    collector.readLocal(new CompactHistoryReader(collector), path.toString(), false);
+                // Read metrics JSON using buffered readers so that Java does not run out of memory
+                try (BufferedJSONReader br = new BufferedJSONReader(new FileReader(path))) {
+                    collector.readBufferedJSON(br);
                 }
             }
             catch (FileNotFoundException ex) {
@@ -521,7 +194,7 @@ public class ImpMetricValue extends BaseImport {
 
     @Override
     public String[] getImportFiles() {
-        return new String[]{"data_metrics.json", "data_history.json"};
+        return new String[]{"data_metrics.json"};
     }
 
 }

--- a/Code/importerjson/src/importer/Importerjson.java
+++ b/Code/importerjson/src/importer/Importerjson.java
@@ -456,7 +456,7 @@ public class Importerjson {
             impCommit.updateJiraID(); // fix developer linking manually (out of json file) after all projects are checked.
             impCommit.showUnknownDevs();
             
-            showCompleteTask("Fixed JIRA and VCS developer linking", startTime);
+            showCompleteTask("Fixed JIRA and VCS/LDAP developer linking", startTime);
         }
         
         if (tasks.contains("metric_domain_name")) {

--- a/Scripts/Database_structure.md
+++ b/Scripts/Database_structure.md
@@ -1199,8 +1199,9 @@ dashboard project definition.
         project to which the norm changes apply.
     -   **version_id** - VARCHAR(100): SHA hash or revision number
         belonging to the change of the target norms.
-    -   **developer** - VARCHAR(64): Developer or quality lead that made
-        the change.
+    -   **developer** - VARCHAR(64) - reference to ldap_developer.name: 
+        Developer or quality lead that made the change. This is NULL if the 
+        developer could not be obtained.
     -   **message** - TEXT: Commit message describing the change. This
         is the empty string if the message is not provided or NULL if it
         could not be obtained.
@@ -1223,18 +1224,28 @@ dashboard project definition.
         to the change of the target norm.
     -   **metric_id** - INT - reference to metric.metric_id: Metric
         whose norms are changed.
-    -   **type** - VARCHAR(100): Type of change: 'options',
-        'old_options' or 'TechnicalDebtTarget'. This is NULL if the type
-        of change comes from Quality Time and it does not contain a
-        technical debt target.
-    -   **target** - INT: Norm value at which the category changes from
-        green to yellow.
-    -   **low_target** - INT: Norm value at which the category changes
-        from yellow to red.
     -   **comment** - TEXT: Comment for technical debt targets
         describing the reason of the norm change. This is the empty
         string if no comment is provided or NULL if it could not be
         obtained.
+    -   **direction** - BOOL: Whether the metric improves if the metric
+        value increases. This is true if a higher value is better, false
+        if a lower value is better, or NULL if it is not known or not
+        applicable for the metric.
+    -   **target** - FLOAT: Norm value at which the category changes from
+        green to yellow. This is NULL if it is unchanged from the deafult.
+    -   **low_target** - FLOAT: Norm value at which the category changes
+        from yellow to red. This is NULL if it is unchanged from the default.
+    -   **debt_target** - FLOAT: Norm value at which the category changes from
+        yellow to grey, indicating a temporary acceptance of technical debt.
+        This is NULL if no debt target is currently active.
+    -   **scale** - VARCHAR(16): Scale of the metric. This can be "count" if 
+        measuring the metric happens by counting items, "percentage" if 
+        a fraction of items is compared to a total/potential of items, 
+        "version_number" if the metric provides a software version, "duration" 
+        if the metric indicates a duration of time in muties or "rating" if the 
+        metric is a rating from 1 to 5 where lower is better. This is NULL if 
+        the scale of the metric is unchanged from the default.
 
 
 -   **metric_default**: The default values of metric targets in the
@@ -1264,6 +1275,13 @@ dashboard project definition.
         target, are indicated by a yellow color in the quality report,
         while worse values are indicated by a red value). This is NULL
         if the low target value is not known.
+    -   **scale** - VARCHAR(16): Scale of the metric. This can be "count" if 
+        measuring the metric happens by counting items, "percentage" if 
+        a fraction of items is compared to a total/potential of items, 
+        "version_number" if the metric provides a software version, "duration" 
+        if the metric indicates a duration of time in muties or "rating" if the 
+        metric is a rating from 1 to 5 where lower is better. This is NULL if 
+        the scale of the metric is not known.
 
 ## Docker dashboard tables (BigBoat)
 

--- a/Scripts/create-tables.sql
+++ b/Scripts/create-tables.sql
@@ -194,7 +194,7 @@ CREATE TABLE "gros"."metric_value" (
 CREATE TABLE "gros"."metric_version" (
 	"project_id"     INTEGER     NOT NULL,
 	"version_id"     VARCHAR(100)     NOT NULL,
-	"developer"      VARCHAR(64) NOT NULL,
+	"developer"      VARCHAR(64) NULL,
 	"message"        TEXT      NULL,
 	"commit_date"    TIMESTAMP NOT NULL,
 	"sprint_id"      INTEGER   NULL,
@@ -206,10 +206,12 @@ CREATE TABLE "gros"."metric_target" (
 	"project_id"     INTEGER     NOT NULL,
 	"version_id"     VARCHAR(100)     NOT NULL,
 	"metric_id"      INTEGER     NOT NULL,
-	"type"           VARCHAR(100) NULL,
-	"target"         INTEGER     NOT NULL,
-	"low_target"     INTEGER     NOT NULL,
-	"comment"        TEXT     NULL
+	"comment"        TEXT     NULL,
+	"direction"      BOOLEAN      NULL,
+	"target"         FLOAT     NULL,
+	"low_target"     FLOAT     NULL,
+	"debt_target"    FLOAT     NULL,
+	"scale"          VARCHAR(16) NULL
 );
 
 CREATE TABLE "gros"."metric_default" (
@@ -220,6 +222,7 @@ CREATE TABLE "gros"."metric_default" (
 	"perfect"        FLOAT     NULL,
 	"target"         FLOAT     NULL,
 	"low_target"     FLOAT     NULL,
+	"scale"          VARCHAR(16) NULL,
 	    CONSTRAINT "pk_metric_default_id" PRIMARY KEY ("base_name", "version_id")
 );
 

--- a/Scripts/update/quality-0.sql
+++ b/Scripts/update/quality-0.sql
@@ -1,0 +1,58 @@
+-- %%
+-- schema: gros
+-- table: metric_default
+-- columns:
+-- - name: scale
+--   action: add
+-- %%
+
+ALTER TABLE "gros"."metric_default" ADD COLUMN "scale" VARCHAR(16) NULL;
+
+-- %%
+-- schema: gros
+-- table: metric_target
+-- columns:
+-- - name: direction
+--   action: add
+-- - name: target
+--   action: alter
+--   "null": true
+-- - name: low_target
+--   action: alter
+--   "null": true
+-- - name: type
+--   action: drop
+-- - name: debt_target
+--   action: add
+-- - name: scale
+--   action: add
+-- %%
+
+ALTER TABLE "gros"."metric_target" ADD COLUMN "direction" BOOLEAN NULL;
+
+ALTER TABLE "gros"."metric_target" ADD COLUMN "new_target" FLOAT NULL;
+UPDATE "gros"."metric_target" SET new_target = target;
+ALTER TABLE "gros"."metric_target" DROP COLUMN "target";
+ALTER TABLE "gros"."metric_target" RENAME COLUMN "new_target" TO "target";
+
+ALTER TABLE "gros"."metric_target" ADD COLUMN "new_low_target" FLOAT NULL;
+UPDATE "gros"."metric_target" SET new_low_target = low_target;
+ALTER TABLE "gros"."metric_target" DROP COLUMN "low_target";
+ALTER TABLE "gros"."metric_target" RENAME COLUMN "new_low_target" TO "low_target";
+
+ALTER TABLE "gros"."metric_target" ADD COLUMN "debt_target" FLOAT NULL;
+UPDATE "gros"."metric_target" SET debt_target = target  WHERE "type" = 'TechnicalDebtTarget';
+
+ALTER TABLE "gros"."metric_target" DROP COLUMN "type";
+ALTER TABLE "gros"."metric_target" ADD COLUMN "scale" VARCHAR(16) NULL;
+
+-- %%
+-- schema: gros
+-- table: metric_version
+-- columns:
+-- - name: developer
+--   action: alter
+--   "null": true
+-- %%
+
+ALTER TABLE "gros"."metric_version" ALTER COLUMN "developer" SET NULL;


### PR DESCRIPTION
- Metric defaults has a new column for scale. If the special task is enabled, then read from the new filename, which is expected to have "base_name" keys in the objects in the array instead of "class_name".
- Metric target no longer stores a type, separate column for debt target with adjusted types for target and low target, new direction column if overridden from default and new column for scale.
- Metric values no longer read files as old history, compact history or reference to local or networked files. The since date from each object in the metrics measurement values file is now optional.
- Metric version developer and message are now optional
- Metric version developer, along with email if provided, are now stored in the LDAP table for linking with Jira developer table. LDAP seems most suitable because the quality report successor, Quality-time, uses LDAP (which can refer to the organization-wide LDAP).